### PR TITLE
chore: initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,723 @@
+# Local Kubernetes Development on Windows with Docker Desktop
+
+This guide covers setting up a local Kubernetes development environment on Windows using Docker Desktop, with Istio service mesh for production parity.
+
+> **Add to README.md:**
+> ```markdown
+> ## Local Development (Windows)
+> See [README.md](README.md) for Windows Docker Desktop Kubernetes setup.
+> ```
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Running the Bootstrap](#running-the-bootstrap)
+3. [Tilt Usage](#tilt-usage)
+4. [DNS and Hostnames](#dns-and-hostnames)
+5. [Gateway Usage](#gateway-usage)
+6. [Egress Control](#egress-control)
+7. [Canary and Blue-Green Deployments](#canary-and-blue-green-deployments)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+### Required Software
+
+| Tool | Version | Installation |
+|------|---------|-------------|
+| Docker Desktop | Latest | [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/) |
+| kubectl | v1.34+ | Included with Docker Desktop, or `choco install kubernetes-cli` |
+| Helm | v3.x | `choco install kubernetes-helm` or [helm.sh/docs/intro/install](https://helm.sh/docs/intro/install/) |
+| Tilt | Latest | `choco install tilt` or [docs.tilt.dev/install](https://docs.tilt.dev/install.html) |
+
+### Optional Tools
+
+| Tool | Purpose | Installation |
+|------|---------|-------------|
+| Git Bash | Unix-like shell | Included with Git for Windows |
+| istioctl | Istio CLI utilities | [istio.io/latest/docs/setup/getting-started](https://istio.io/latest/docs/setup/getting-started/) |
+
+### Enable Docker Desktop Kubernetes
+
+1. Open Docker Desktop
+2. Go to **Settings** → **Kubernetes**
+3. Check **Enable Kubernetes**
+4. Click **Apply & Restart**
+5. Wait for the Kubernetes indicator to turn green
+
+Verify setup:
+```powershell
+kubectl config use-context docker-desktop
+kubectl cluster-info
+kubectl config current-context  # Should show: docker-desktop
+```
+
+---
+
+## Running the Bootstrap
+
+The bootstrap script is idempotent and safe to run multiple times.
+
+### Basic Usage (Sidecar Mode)
+
+```powershell
+# Navigate to repo root
+cd path\to\your\repo
+
+# Run with defaults (sidecar mode, no gateway)
+.\scripts\bootstrap-docker-desktop-k8s.ps1
+```
+
+### All Parameters
+
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 `
+    -DataplaneMode sidecar `    # Options: sidecar (default), ambient, none
+    -InstallIngressGateway `    # Enable Istio ingress gateway
+    -InstallDashboard `         # Install Kubernetes Dashboard
+    -AllowInternetEgress `      # Allow pods to reach internet
+    -Force                      # Bypass kubecontext safety check
+
+# One Liner for above
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -DataplaneMode sidecar -InstallIngressGateway -InstallDashboard -AllowInternetEgress -Force
+```
+
+### Common Scenarios
+
+**Minimal Dev Setup (fastest startup):**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -DataplaneMode none
+```
+
+**Standard Dev with Sidecar Injection:**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1
+```
+
+**Production-Like with Gateway:**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -InstallIngressGateway
+```
+
+**Ambient Mode (Sidecar-less):**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -DataplaneMode ambient -InstallIngressGateway
+```
+
+**Full Setup with Dashboard and Egress:**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 `
+    -DataplaneMode sidecar `
+    -InstallIngressGateway `
+    -InstallDashboard `
+    -AllowInternetEgress
+```
+
+### What the Bootstrap Does
+
+1. **Validates environment**: Checks kubectl, helm, kubecontext, StorageClass
+2. **Installs Gateway API CRDs**: Required for Istio gateway resources
+3. **Installs Istio 1.28.2**: Base, Istiod, optionally ztunnel and gateway
+4. **Creates platform-dev namespace**: With appropriate mesh enrollment labels
+5. **Applies Zero Trust policies**:
+   - PeerAuthentication: mTLS STRICT
+   - AuthorizationPolicy: default-deny + allow intra-namespace
+   - NetworkPolicy: default-deny + allow DNS
+6. **Optional components**: Ingress gateway, Kubernetes Dashboard
+
+---
+
+## Tilt Usage
+
+### Starting Tilt in Kubernetes Mode
+
+```powershell
+# Standard mode with Istio sidecar injection
+tilt up -- --mode=k8s --k8s-istio-enabled=true
+
+# With gateway management (requires -InstallIngressGateway)
+tilt up -- --mode=k8s --k8s-istio-enabled=true --k8s-manage-gateway=true
+
+# Override gateway name if needed
+tilt up -- --mode=k8s --k8s-istio-enabled=true --k8s-manage-gateway=true --k8s-gateway-name=platform-gateway
+```
+
+### Important Tilt Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mode` | - | Deployment mode: `k8s` for Kubernetes |
+| `--k8s-istio-enabled` | false | Enable Istio-aware deployments |
+| `--k8s-manage-gateway` | false | Apply k8s/gateway.yaml via Tilt |
+| `--k8s-gateway-name` | platform-gateway | Gateway resource name |
+
+### Tilt UI
+
+Once running, access Tilt dashboard at: **http://localhost:10350**
+
+### Stopping Tilt
+
+Press `Ctrl+C` or run `tilt down` to clean up resources.
+
+---
+
+## DNS and Hostnames
+
+### Recommended: localtest.me
+
+Use `localtest.me` for local development. This domain resolves to `127.0.0.1` without any `/etc/hosts` modification.
+
+**Examples:**
+```
+http://platform.localtest.me
+http://api.platform.localtest.me
+http://admin.platform.localtest.me:8080
+```
+
+Any subdomain works: `*.localtest.me` → `127.0.0.1`
+
+### Using with Ingress Gateway
+
+When the ingress gateway is installed, it exposes a LoadBalancer service on localhost (Docker Desktop handles this automatically).
+
+```powershell
+# Check gateway service
+kubectl get svc istio-ingressgateway -n istio-system
+
+# Example output:
+# NAME                   TYPE           EXTERNAL-IP   PORT(S)
+# istio-ingressgateway   LoadBalancer   localhost     15021,80,443
+```
+
+Access your services via:
+- `http://platform.localtest.me` (port 80)
+- `https://platform.localtest.me` (port 443, requires TLS config)
+
+### Alternative: Direct Port Forwarding
+
+Without a gateway, use `kubectl port-forward` or Tilt's `port_forward`:
+
+```powershell
+# Manual port-forward
+kubectl port-forward svc/my-service -n platform-dev 8080:80
+
+# Access at http://localhost:8080
+```
+
+---
+
+## Gateway Usage
+
+### Simple Dev: No Gateway
+
+For rapid iteration, skip the gateway entirely:
+
+```powershell
+# Bootstrap without gateway
+.\scripts\bootstrap-docker-desktop-k8s.ps1
+
+# Use Tilt port_forwards or kubectl port-forward
+tilt up -- --mode=k8s --k8s-istio-enabled=true
+```
+
+Access services via Tilt's port forwards shown in Tilt UI.
+
+### Production-Like: With Ingress Gateway
+
+For testing gateway routing, TLS termination, or traffic management:
+
+```powershell
+# Bootstrap with gateway
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -InstallIngressGateway
+
+# Run Tilt with gateway management
+tilt up -- --mode=k8s --k8s-istio-enabled=true --k8s-manage-gateway=true
+```
+
+This applies `k8s/gateway.yaml` which defines Gateway and HTTPRoute resources.
+
+### Gateway Configuration for localtest.me
+
+If your `k8s/gateway.yaml` uses `platform.local` hostnames, create a dev-friendly variant:
+
+**Option A: Wildcard Host**
+```yaml
+# In gateway.yaml or a local override
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: platform-routes
+  namespace: platform-dev
+spec:
+  parentRefs:
+    - name: platform-gateway
+      namespace: istio-system
+  hostnames:
+    - "*.localtest.me"      # Wildcard for dev
+    - "platform.localtest.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: api-service
+          port: 80
+    - backendRefs:
+        - name: frontend-service
+          port: 80
+```
+
+**Option B: Tiltfile Override**
+
+In your Tiltfile, conditionally modify hostnames for local development.
+
+---
+
+## Egress Control
+
+### Default: Locked Down
+
+By default, pods in `platform-dev` can only reach:
+- Other pods in `platform-dev` (intra-namespace)
+- Kubernetes DNS (`kube-dns` in `kube-system`)
+
+All other egress (including internet) is blocked by NetworkPolicy.
+
+### Enabling Internet Egress
+
+For development scenarios requiring external API access:
+
+```powershell
+# At bootstrap time
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -AllowInternetEgress
+
+# Or apply manually
+kubectl apply -f k8s/dev/networkpolicies/np-allow-internet-egress.yaml
+```
+
+### Fine-Grained Egress with Istio ServiceEntry
+
+For production-like control over external services, use Istio ServiceEntry instead of blanket NetworkPolicy rules.
+
+**Example: Allow access to external API**
+```yaml
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: external-api
+  namespace: platform-dev
+spec:
+  hosts:
+    - api.example.com
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+  location: MESH_EXTERNAL
+  resolution: DNS
+```
+
+**When to use ServiceEntry:**
+- You need to track metrics for external calls
+- You want to apply retry/timeout policies to external services
+- You need to enforce mTLS to external endpoints
+- Production uses ServiceEntry and you want parity
+
+**When NetworkPolicy egress is enough:**
+- Simple development scenarios
+- You don't need Istio observability for external calls
+- Faster iteration without additional configuration
+
+---
+
+## Canary and Blue-Green Deployments
+
+Istio enables sophisticated traffic management for canary releases and blue-green deployments.
+
+### Prerequisites
+
+**Sidecar Mode:** Works out of the box with sidecar proxies.
+
+**Ambient Mode:** Requires waypoint proxy for L7 traffic management.
+
+```powershell
+# Verify waypoint is running (ambient mode only)
+kubectl get gateway -n platform-dev
+kubectl get pods -n platform-dev -l gateway.networking.k8s.io/gateway-name=waypoint
+```
+
+### Example: Canary Deployment
+
+**1. Deploy both versions with version labels:**
+```yaml
+# v1 deployment (stable)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v1
+  namespace: platform-dev
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1
+    spec:
+      containers:
+        - name: app
+          image: my-app:1.0.0
+
+---
+# v2 deployment (canary)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v2
+  namespace: platform-dev
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v2
+    spec:
+      containers:
+        - name: app
+          image: my-app:2.0.0
+```
+
+**2. Apply DestinationRule (defines subsets):**
+```powershell
+kubectl apply -f k8s/dev/traffic/canary-destinationrule.yaml
+```
+
+**3. Apply VirtualService (defines traffic split):**
+```powershell
+kubectl apply -f k8s/dev/traffic/canary-virtualservice.yaml
+```
+
+**4. Adjust traffic weights:**
+
+Edit `canary-virtualservice.yaml` to change the split:
+```yaml
+# 90% to v1, 10% to v2 (initial canary)
+route:
+  - destination:
+      host: my-app
+      subset: stable
+    weight: 90
+  - destination:
+      host: my-app
+      subset: canary
+    weight: 10
+```
+
+Gradually increase canary weight as confidence grows:
+- 90/10 → 80/20 → 50/50 → 20/80 → 0/100
+
+### Blue-Green with Instant Cutover
+
+For blue-green, use 100% weights:
+
+```yaml
+# Blue is live
+route:
+  - destination:
+      host: my-app
+      subset: blue
+    weight: 100
+  - destination:
+      host: my-app
+      subset: green
+    weight: 0
+
+# Cutover to green
+route:
+  - destination:
+      host: my-app
+      subset: blue
+    weight: 0
+  - destination:
+      host: my-app
+      subset: green
+    weight: 100
+```
+
+### Header-Based Routing (Testing Canary)
+
+Route specific requests to canary based on headers:
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: my-app
+  namespace: platform-dev
+spec:
+  hosts:
+    - my-app
+  http:
+    # Route test traffic to canary
+    - match:
+        - headers:
+            x-canary:
+              exact: "true"
+      route:
+        - destination:
+            host: my-app
+            subset: canary
+    # Default: all other traffic to stable
+    - route:
+        - destination:
+            host: my-app
+            subset: stable
+```
+
+Test with:
+```powershell
+curl -H "x-canary: true" http://my-app.platform-dev.svc.cluster.local
+```
+
+---
+
+## Troubleshooting
+
+### Context Mismatch
+
+**Symptom:** Bootstrap fails with "kubecontext is not docker-desktop"
+
+**Solution:**
+```powershell
+# List available contexts
+kubectl config get-contexts
+
+# Switch to docker-desktop
+kubectl config use-context docker-desktop
+
+# Verify
+kubectl config current-context
+```
+
+**Bypass (not recommended):**
+```powershell
+.\scripts\bootstrap-docker-desktop-k8s.ps1 -Force
+```
+
+### Image Pull Issues
+
+**Symptom:** Pods stuck in `ImagePullBackOff` or `ErrImagePull`
+
+**Solutions:**
+
+1. **Check image name/tag:**
+   ```powershell
+   kubectl describe pod <pod-name> -n platform-dev | Select-String -Pattern "Image:"
+   ```
+
+2. **For local images, ensure they're built:**
+   ```powershell
+   docker images | Select-String "my-app"
+   ```
+
+3. **Docker Desktop image sharing:**
+   Docker Desktop Kubernetes uses the same Docker daemon, so locally built images are available without pushing to a registry.
+
+4. **Private registry auth:**
+   ```powershell
+   kubectl create secret docker-registry regcred `
+       --docker-server=<registry> `
+       --docker-username=<user> `
+       --docker-password=<password> `
+       -n platform-dev
+   ```
+
+### Resetting Docker Desktop Kubernetes
+
+**When to reset:**
+- Cluster in bad state
+- Storage issues
+- Want a fresh start
+
+**Steps:**
+1. Open Docker Desktop
+2. Go to **Settings** → **Kubernetes**
+3. Click **Reset Kubernetes Cluster**
+4. Wait for reset to complete
+5. Re-run bootstrap script
+
+**Note:** This deletes all Kubernetes resources but preserves Docker images.
+
+### Dashboard Access and Tokens
+
+**Start port forward:**
+```powershell
+kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+```
+
+**Access:** https://localhost:8443
+
+**Create a viewer token (safe for dev):**
+```powershell
+# Create service account
+kubectl create serviceaccount dashboard-viewer -n kubernetes-dashboard
+
+# Grant view permissions
+kubectl create clusterrolebinding dashboard-viewer `
+    --clusterrole=view `
+    --serviceaccount=kubernetes-dashboard:dashboard-viewer
+
+# Generate token
+kubectl create token dashboard-viewer -n kubernetes-dashboard
+```
+
+**Security Warning:** Never create cluster-admin tokens. Use RBAC to grant minimum necessary permissions.
+
+### Istio Sidecar Not Injecting
+
+**Symptom:** Pods don't have istio-proxy container
+
+**Check namespace labels:**
+```powershell
+kubectl get namespace platform-dev --show-labels
+```
+
+**Expected for sidecar mode:**
+```
+istio-injection=enabled
+```
+
+**Fix:**
+```powershell
+kubectl label namespace platform-dev istio-injection=enabled --overwrite
+# Restart pods to inject sidecar
+kubectl rollout restart deployment -n platform-dev
+```
+
+### Ambient Mode: L7 Features Not Working
+
+**Symptom:** VirtualService routing rules not applied
+
+**Cause:** Ambient mode requires waypoint proxy for L7 features
+
+**Solution:**
+```powershell
+# Check if waypoint exists
+kubectl get gateway -n platform-dev
+
+# Apply waypoint if missing
+kubectl apply -f k8s/dev/ambient/waypoint-platform-dev.yaml
+
+# Verify waypoint pods
+kubectl get pods -n platform-dev -l gateway.networking.k8s.io/gateway-name=waypoint
+```
+
+### mTLS Verification
+
+**Check mTLS status:**
+```powershell
+# Requires istioctl
+istioctl authn tls-check <pod-name>.<namespace> -n <namespace>
+
+# Example
+istioctl authn tls-check my-app-abc123.platform-dev -n platform-dev
+```
+
+**Check PeerAuthentication:**
+```powershell
+kubectl get peerauthentication -n platform-dev
+```
+
+### NetworkPolicy Blocking Traffic
+
+**Symptom:** Pods can't communicate
+
+**Debug:**
+```powershell
+# List network policies
+kubectl get networkpolicy -n platform-dev
+
+# Check pod labels (must match policy selectors)
+kubectl get pods -n platform-dev --show-labels
+
+# Describe policy
+kubectl describe networkpolicy np-default-deny -n platform-dev
+```
+
+**Temporary bypass (debugging only):**
+```powershell
+kubectl delete networkpolicy np-default-deny -n platform-dev
+# Don't forget to re-apply after debugging!
+```
+
+### Logs and Debugging
+
+**Istiod logs:**
+```powershell
+kubectl logs -l app=istiod -n istio-system -f
+```
+
+**Sidecar logs:**
+```powershell
+kubectl logs <pod-name> -c istio-proxy -n platform-dev
+```
+
+**Ztunnel logs (ambient mode):**
+```powershell
+kubectl logs -l app=ztunnel -n istio-system -f
+```
+
+**Waypoint logs (ambient mode):**
+```powershell
+kubectl logs -l gateway.networking.k8s.io/gateway-name=waypoint -n platform-dev -f
+```
+
+---
+
+## Quick Reference
+
+### Common Commands
+
+```powershell
+# Bootstrap (re-run safe)
+.\scripts\bootstrap-docker-desktop-k8s.ps1
+
+# Start Tilt
+tilt up -- --mode=k8s --k8s-istio-enabled=true
+
+# Check pod status
+kubectl get pods -n platform-dev
+
+# Check Istio
+kubectl get pods -n istio-system
+helm list -n istio-system
+
+# Restart deployment (trigger sidecar injection)
+kubectl rollout restart deployment/<name> -n platform-dev
+
+# Port forward
+kubectl port-forward svc/<service> -n platform-dev 8080:80
+
+# Dashboard
+kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+```
+
+### Namespace Labels by Mode
+
+| Mode | Labels |
+|------|--------|
+| sidecar | `istio-injection=enabled` |
+| ambient | `istio.io/dataplane-mode=ambient` |
+| none | (no Istio labels) |

--- a/k8s/dev/ambient/waypoint-platform-dev.yaml
+++ b/k8s/dev/ambient/waypoint-platform-dev.yaml
@@ -1,0 +1,84 @@
+# Waypoint Proxy: Enable L7 traffic management in Ambient mode
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# PURPOSE: L7 traffic management in Ambient mesh
+#   - Ambient mode uses ztunnel for L4 (mTLS, basic allow/deny)
+#   - Waypoint proxy adds L7 capabilities:
+#     - HTTP request routing (VirtualService)
+#     - Header-based routing
+#     - Retries and timeouts
+#     - Circuit breaking
+#     - Traffic mirroring
+#
+# WHEN REQUIRED:
+#   - VirtualService with HTTP match rules
+#   - DestinationRule with traffic policy
+#   - Any L7 (application-layer) traffic shaping
+#
+# WHEN NOT REQUIRED:
+#   - Basic mTLS encryption (ztunnel handles this)
+#   - Simple AuthorizationPolicies without L7 conditions
+#   - L4 load balancing
+#
+# USAGE:
+#   - Bootstrap applies this when -DataplaneMode ambient
+#   - Manual: kubectl apply -f k8s/dev/ambient/waypoint-platform-dev.yaml
+#
+# HOW IT WORKS:
+#   - Creates a Kubernetes Gateway resource (Gateway API)
+#   - Istio deploys waypoint proxy pods in the namespace
+#   - Traffic to services enrolled in waypoint flows through it
+#   - Waypoint is namespace-scoped by default
+#
+# SERVICE ENROLLMENT:
+#   - By default, waypoint handles traffic for the entire namespace
+#   - For service-specific waypoints, use gatewayClassName: istio-waypoint
+#     with service-level annotations
+#
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-ambient
+    # Standard Istio waypoint label
+    istio.io/waypoint-for: all
+spec:
+  # This gatewayClassName tells Istio to create a waypoint proxy
+  gatewayClassName: istio-waypoint
+  listeners:
+    # Waypoint listener - handles all L7 traffic for enrolled workloads
+    - name: mesh
+      port: 15008
+      protocol: HBONE
+      # AllowedRoutes not strictly required for waypoint
+      # but included for clarity
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# Example: Enrolling a specific service in the waypoint
+# Uncomment and modify for service-specific waypoint routing
+#
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: my-app
+#   namespace: platform-dev
+#   labels:
+#     app: my-app
+#   annotations:
+#     # This annotation enrolls the service in the waypoint
+#     istio.io/use-waypoint: waypoint
+# spec:
+#   selector:
+#     app: my-app
+#   ports:
+#     - name: http
+#       port: 80
+#       targetPort: 8080

--- a/k8s/dev/networkpolicies/np-allow-dns.yaml
+++ b/k8s/dev/networkpolicies/np-allow-dns.yaml
@@ -1,0 +1,54 @@
+# NetworkPolicy: Allow DNS queries to kube-dns
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# PURPOSE: Essential for service discovery
+#   - Without DNS, pods cannot resolve service names
+#   - This allows pods to query kube-dns (CoreDNS) in kube-system
+#   - Required even in a locked-down namespace
+#
+# SECURITY:
+#   - Only allows UDP/TCP port 53 to kube-dns
+#   - Does not allow other egress (handled by separate policies)
+#   - Scoped to kube-system namespace only
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - podSelector: {} means "all pods in this namespace"
+#   - Only affects egress to kube-system namespace on DNS port
+#
+# COMPATIBILITY:
+#   - Works with Docker Desktop's CoreDNS
+#   - Works with most Kubernetes distributions
+#   - Uses label selector for kube-dns service
+#
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # Empty podSelector = applies to all pods in namespace
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # Allow DNS queries to kube-dns in kube-system namespace
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        # DNS over UDP (standard)
+        - protocol: UDP
+          port: 53
+        # DNS over TCP (for large responses)
+        - protocol: TCP
+          port: 53

--- a/k8s/dev/networkpolicies/np-allow-internet-egress.yaml
+++ b/k8s/dev/networkpolicies/np-allow-internet-egress.yaml
@@ -1,0 +1,69 @@
+# NetworkPolicy: Allow internet egress from platform-dev
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# USAGE: OPTIONAL - Only apply when internet access is needed
+#   - Bootstrap applies this when -AllowInternetEgress is used
+#   - Manual: kubectl apply -f k8s/dev/networkpolicies/np-allow-internet-egress.yaml
+#   - Remove: kubectl delete -f k8s/dev/networkpolicies/np-allow-internet-egress.yaml
+#
+# PURPOSE:
+#   - Allows pods to reach external internet services
+#   - Useful for development requiring external APIs
+#   - NOT recommended for production-like testing
+#
+# SECURITY CONSIDERATIONS:
+#   - Opens egress to ANY external IP
+#   - Consider Istio ServiceEntry for fine-grained control
+#   - Production should use explicit allowlists
+#   - Excludes internal Kubernetes networks (10.0.0.0/8, etc.)
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - podSelector: {} means "all pods in this namespace"
+#   - Allows egress to external IPs only (not internal cluster)
+#
+# ALTERNATIVE: Use Istio ServiceEntry for production-like control
+#   - ServiceEntry gives observability into external calls
+#   - ServiceEntry can apply retry/timeout policies
+#   - See docs for ServiceEntry examples
+#
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internet-egress
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+    # Mark as optional for easy identification
+    app.kubernetes.io/component: optional
+spec:
+  # Empty podSelector = applies to all pods in namespace
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # Allow egress to external networks (internet)
+    # This uses ipBlock to allow external IPs while excluding internal ranges
+    - to:
+        # Allow all external IPs except private ranges
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              # Exclude private networks (RFC 1918)
+              - 10.0.0.0/8       # Class A private
+              - 172.16.0.0/12    # Class B private (includes Docker networks)
+              - 192.168.0.0/16   # Class C private
+              # Exclude link-local
+              - 169.254.0.0/16   # APIPA / link-local
+              # Exclude loopback
+              - 127.0.0.0/8      # Localhost
+      ports:
+        # HTTPS (most external APIs)
+        - protocol: TCP
+          port: 443
+        # HTTP (some APIs, package repos)
+        - protocol: TCP
+          port: 80

--- a/k8s/dev/networkpolicies/np-default-deny.yaml
+++ b/k8s/dev/networkpolicies/np-default-deny.yaml
@@ -1,0 +1,45 @@
+# NetworkPolicy: Default deny all ingress and egress in platform-dev
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# SECURITY: Defense in depth
+#   - Network-level isolation (CNI enforced, works without Istio)
+#   - Denies ALL ingress and egress traffic by default
+#   - Istio AuthorizationPolicies provide application-layer (L7) control
+#   - NetworkPolicies provide network-layer (L3/L4) control
+#
+# WHY BOTH ISTIO AND NETWORK POLICIES?
+#   - Defense in depth: multiple layers of security
+#   - NetworkPolicies work even if Istio sidecars fail
+#   - NetworkPolicies can block traffic before it reaches the proxy
+#   - Different enforcement points catch different attack vectors
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - podSelector: {} means "all pods in this namespace"
+#   - Empty ingress/egress arrays = deny all
+#
+# IMPORTANT: This policy alone blocks ALL traffic. Combine with:
+#   - np-allow-dns.yaml (required for service discovery)
+#   - np-allow-internet-egress.yaml (optional, for external access)
+#
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # Empty podSelector = applies to all pods in namespace
+  podSelector: {}
+  # Specifying both Ingress and Egress makes this a "default deny all" policy
+  policyTypes:
+    - Ingress
+    - Egress
+  # Empty arrays = no traffic allowed
+  # Other NetworkPolicies will add specific allow rules
+  ingress: []
+  egress: []

--- a/k8s/dev/security/authz-allow-from-ingressgateway.yaml
+++ b/k8s/dev/security/authz-allow-from-ingressgateway.yaml
@@ -1,0 +1,55 @@
+# AuthorizationPolicy: Allow traffic from Istio Ingress Gateway
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# USAGE: Apply this ONLY when ingress gateway is installed
+#   - Bootstrap applies this when -InstallIngressGateway is used
+#   - Not needed for port-forward or NodePort access patterns
+#
+# SECURITY: Controlled ingress path
+#   - Only allows traffic FROM the istio-ingressgateway service account
+#   - Does not allow arbitrary external traffic
+#   - Gateway itself handles edge security (TLS termination, rate limiting, etc.)
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - Empty selector {} means "all workloads in this namespace"
+#   - Only ingress gateway traffic is allowed by this policy
+#
+# PREREQUISITE: Ingress gateway must be installed in istio-system
+#   - Default service account: istio-ingressgateway-service-account
+#
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-from-ingressgateway
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # Empty selector = applies to all workloads in namespace
+  selector: {}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            # Allow traffic from istio ingress gateway
+            # This matches the gateway's SPIFFE identity
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+      to:
+        - operation:
+            # Allow standard HTTP methods used by ingress
+            methods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - HEAD
+              - OPTIONS
+            # Allow all paths - gateway routes handle path filtering
+            paths:
+              - "/*"

--- a/k8s/dev/security/authz-allow-intra-namespace.yaml
+++ b/k8s/dev/security/authz-allow-intra-namespace.yaml
@@ -1,0 +1,47 @@
+# AuthorizationPolicy: Allow traffic within platform-dev namespace
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# SECURITY: Zero Trust posture with intra-namespace communication
+#   - Allows pods within platform-dev to communicate with each other
+#   - Traffic must still be mTLS (enforced by PeerAuthentication)
+#   - External traffic (from other namespaces) remains blocked unless explicitly allowed
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - Empty selector {} means "all workloads in this namespace"
+#   - Only allows traffic FROM principals in platform-dev namespace
+#
+# HOW IT WORKS:
+#   - Istio assigns each pod a SPIFFE identity based on its service account
+#   - Format: cluster.local/ns/<namespace>/sa/<service-account>
+#   - This policy allows any identity from platform-dev namespace
+#
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # Empty selector = applies to all workloads in namespace
+  selector: {}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            # Allow any workload from platform-dev namespace
+            # The * wildcard matches any service account in the namespace
+            namespaces:
+              - platform-dev
+      to:
+        - operation:
+            # Allow all HTTP methods
+            methods:
+              - "*"
+            # Allow all paths
+            paths:
+              - "/*"

--- a/k8s/dev/security/authz-default-deny.yaml
+++ b/k8s/dev/security/authz-default-deny.yaml
@@ -1,0 +1,32 @@
+# AuthorizationPolicy: Default DENY all traffic in platform-dev
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# SECURITY: Zero Trust posture
+#   - Denies ALL traffic by default
+#   - Explicit allow policies must be created for any communication
+#   - Works with both sidecar and ambient dataplane modes
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - Empty selector {} means "all workloads in this namespace"
+#   - Does not affect other namespaces
+#
+# IMPORTANT: This policy alone blocks ALL traffic. Combine with:
+#   - authz-allow-intra-namespace.yaml (allows pod-to-pod within namespace)
+#   - authz-allow-from-ingressgateway.yaml (allows gateway->service, optional)
+#
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: default-deny
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # Empty selector = applies to all workloads in namespace
+  selector: {}
+  # No rules = deny everything (implicit deny when action is missing)
+  # This is equivalent to action: DENY with no rules

--- a/k8s/dev/security/peerauthentication-strict.yaml
+++ b/k8s/dev/security/peerauthentication-strict.yaml
@@ -1,0 +1,28 @@
+# PeerAuthentication: Enforce mTLS STRICT in platform-dev namespace
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# SECURITY: Zero Trust posture
+#   - All pod-to-pod traffic must be mTLS encrypted
+#   - No plaintext traffic allowed within the mesh
+#   - Sidecars (or ztunnel in ambient mode) enforce this automatically
+#
+# SCOPE: Namespace-level (platform-dev only)
+#   - Does not affect other namespaces
+#   - Workloads must be enrolled in the mesh to communicate
+#
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-security
+spec:
+  # STRICT: Require mTLS for all traffic
+  # Options: STRICT | PERMISSIVE | DISABLE | UNSET
+  mtls:
+    mode: STRICT

--- a/k8s/dev/traffic/canary-destinationrule.yaml
+++ b/k8s/dev/traffic/canary-destinationrule.yaml
@@ -1,0 +1,87 @@
+# DestinationRule: Define version subsets for canary/blue-green deployments
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# PURPOSE: Traffic management with version-based routing
+#   - Defines subsets based on pod labels (version: v1, v2, etc.)
+#   - Used with VirtualService to split traffic between versions
+#   - Enables canary releases, blue-green deployments, A/B testing
+#
+# PREREQUISITES:
+#   - Deployments must have version labels: version: v1, version: v2, etc.
+#   - A Service selecting both versions (app: my-app)
+#   - VirtualService referencing these subsets
+#
+# AMBIENT MODE NOTE:
+#   - Requires waypoint proxy for L7 traffic management
+#   - Without waypoint, DestinationRule traffic policies won't apply
+#   - Ensure waypoint-platform-dev.yaml is applied
+#
+# USAGE:
+#   1. Deploy your app with version labels
+#   2. Apply this DestinationRule
+#   3. Apply canary-virtualservice.yaml with desired weights
+#   4. Adjust weights in VirtualService for gradual rollout
+#
+# CUSTOMIZATION:
+#   - Change 'my-app' to your actual service name
+#   - Add more subsets for multi-version deployments
+#   - Adjust connectionPool for traffic tuning
+#
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: my-app
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-traffic
+spec:
+  # Target service - must match the Kubernetes Service name
+  host: my-app
+  
+  # Traffic policy applied to all subsets (can be overridden per-subset)
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+        http2MaxRequests: 1000
+    # Load balancing for subset selection
+    loadBalancer:
+      simple: ROUND_ROBIN
+  
+  # Version subsets - must match pod labels
+  subsets:
+    # Stable version (v1)
+    - name: stable
+      labels:
+        version: v1
+      # Optional: subset-specific traffic policy
+      trafficPolicy:
+        connectionPool:
+          http:
+            http2MaxRequests: 500
+    
+    # Canary version (v2)
+    - name: canary
+      labels:
+        version: v2
+      trafficPolicy:
+        connectionPool:
+          http:
+            # Lower limits for canary to limit blast radius
+            http2MaxRequests: 100
+    
+    # Blue-green alternative labels
+    # Uncomment if using blue/green naming instead of stable/canary
+    # - name: blue
+    #   labels:
+    #     version: blue
+    # - name: green
+    #   labels:
+    #     version: green

--- a/k8s/dev/traffic/canary-virtualservice.yaml
+++ b/k8s/dev/traffic/canary-virtualservice.yaml
@@ -1,0 +1,143 @@
+# VirtualService: Traffic splitting for canary deployments
+#
+# IDEMPOTENCY: Safe to apply multiple times (kubectl apply -f)
+#   - Creates resource if missing
+#   - Updates to desired state if exists
+#
+# PURPOSE: Weighted traffic distribution between versions
+#   - Gradually shift traffic from stable to canary
+#   - Monitor canary health before increasing percentage
+#   - Instant rollback by setting canary weight to 0
+#
+# CANARY ROLLOUT STRATEGY:
+#   1. Deploy canary (v2) alongside stable (v1)
+#   2. Start with 90/10 split (this file's default)
+#   3. Monitor metrics and errors
+#   4. Gradually increase: 80/20 → 50/50 → 20/80 → 0/100
+#   5. Once confident, remove v1 deployment
+#
+# PREREQUISITES:
+#   - canary-destinationrule.yaml applied (defines subsets)
+#   - Service 'my-app' exists with pods labeled version: v1 and v2
+#   - AMBIENT MODE: waypoint proxy must be running for L7 routing
+#
+# CUSTOMIZATION:
+#   - Change 'my-app' to your actual service name
+#   - Adjust weights for desired traffic split
+#   - Add match rules for header-based routing (testing canary)
+#
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: my-app
+  namespace: platform-dev
+  labels:
+    app.kubernetes.io/managed-by: bootstrap-script
+    app.kubernetes.io/part-of: platform-traffic
+spec:
+  # Target host - must match the Kubernetes Service name
+  hosts:
+    - my-app
+  
+  http:
+    # -----------------------------------------------------------------
+    # Rule 1: Header-based canary testing
+    # Allows developers to test canary without affecting other traffic
+    # -----------------------------------------------------------------
+    - name: canary-test
+      match:
+        - headers:
+            x-canary:
+              exact: "true"
+      route:
+        - destination:
+            host: my-app
+            subset: canary
+          weight: 100
+      # Canary-specific timeouts
+      timeout: 30s
+      retries:
+        attempts: 2
+        perTryTimeout: 10s
+        retryOn: 5xx,reset,connect-failure
+    
+    # -----------------------------------------------------------------
+    # Rule 2: Weighted traffic split (main canary rule)
+    # Adjust weights to control rollout percentage
+    # -----------------------------------------------------------------
+    - name: canary-rollout
+      route:
+        # Stable (v1) - receives most traffic
+        - destination:
+            host: my-app
+            subset: stable
+          weight: 90
+        # Canary (v2) - receives small percentage
+        - destination:
+            host: my-app
+            subset: canary
+          weight: 10
+      # Timeout and retry policy
+      timeout: 30s
+      retries:
+        attempts: 3
+        perTryTimeout: 10s
+        retryOn: 5xx,reset,connect-failure,retriable-4xx
+
+# -----------------------------------------------------------------
+# ROLLOUT PROGRESSION EXAMPLES
+# -----------------------------------------------------------------
+# Copy and paste these weight configurations as you progress:
+#
+# Initial canary (10%):
+#   - subset: stable, weight: 90
+#   - subset: canary, weight: 10
+#
+# Growing canary (25%):
+#   - subset: stable, weight: 75
+#   - subset: canary, weight: 25
+#
+# Half-and-half (50%):
+#   - subset: stable, weight: 50
+#   - subset: canary, weight: 50
+#
+# Canary majority (75%):
+#   - subset: stable, weight: 25
+#   - subset: canary, weight: 75
+#
+# Full cutover (100%):
+#   - subset: stable, weight: 0
+#   - subset: canary, weight: 100
+#
+# Instant rollback:
+#   - subset: stable, weight: 100
+#   - subset: canary, weight: 0
+# -----------------------------------------------------------------
+
+# -----------------------------------------------------------------
+# BLUE-GREEN ALTERNATIVE
+# -----------------------------------------------------------------
+# For blue-green deployments, use 100/0 weights:
+#
+# Blue live:
+#   route:
+#     - destination:
+#         host: my-app
+#         subset: blue
+#       weight: 100
+#     - destination:
+#         host: my-app
+#         subset: green
+#       weight: 0
+#
+# Cutover to green:
+#   route:
+#     - destination:
+#         host: my-app
+#         subset: blue
+#       weight: 0
+#     - destination:
+#         host: my-app
+#         subset: green
+#       weight: 100
+# -----------------------------------------------------------------

--- a/scripts/bootstrap-docker-desktop-k8s.ps1
+++ b/scripts/bootstrap-docker-desktop-k8s.ps1
@@ -1,0 +1,822 @@
+<#
+.SYNOPSIS
+    Idempotent bootstrap for Docker Desktop Kubernetes with Istio service mesh.
+
+.DESCRIPTION
+    This script sets up a local Kubernetes development environment on Docker Desktop
+    with Istio 1.28.2 service mesh, supporting both Sidecar and Ambient dataplane modes.
+    
+    Designed for Windows 10/11 with PowerShell 5.1+ or PowerShell 7+.
+    
+    IDEMPOTENCY RULES:
+    - Safe to run multiple times with no harmful side-effects
+    - Uses helm upgrade --install (never raw install)
+    - Uses kubectl apply -f for YAML
+    - Creates namespaces only when missing
+    - Labels/annotates with --overwrite only on intended keys
+    - Never deletes or resets resources automatically
+    - Fails fast with actionable errors
+
+.PARAMETER Force
+    Bypass kubecontext safety check (proceed even if not docker-desktop).
+
+.PARAMETER DataplaneMode
+    Istio dataplane mode for platform-dev namespace enrollment.
+    - sidecar: Standard sidecar injection (default)
+    - ambient: Ambient mesh with ztunnel (L4) + optional waypoint (L7)
+    - none: No Istio enrollment for platform-dev
+
+.PARAMETER InstallIngressGateway
+    Install Istio ingress gateway for production-like routing.
+
+.PARAMETER InstallDashboard
+    Install Kubernetes Dashboard for cluster visibility.
+
+.PARAMETER AllowInternetEgress
+    Apply NetworkPolicy allowing internet egress from platform-dev.
+
+.PARAMETER IstioNamespace
+    Namespace for Istio control plane components.
+
+.PARAMETER PlatformNamespace
+    Application namespace for development workloads.
+
+.PARAMETER IstioVersion
+    Pinned Istio version (must match chart versions).
+
+.PARAMETER UseGitBash
+    Reserved for future quoting compatibility; currently unused.
+
+.EXAMPLE
+    .\bootstrap-docker-desktop-k8s.ps1
+    # Default: Sidecar mode, no gateway, no dashboard
+
+.EXAMPLE
+    .\bootstrap-docker-desktop-k8s.ps1 -DataplaneMode ambient -InstallIngressGateway
+    # Ambient mode with ingress gateway
+
+.EXAMPLE
+    .\bootstrap-docker-desktop-k8s.ps1 -Force -InstallDashboard -AllowInternetEgress
+    # Force run with dashboard and internet egress enabled
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Force = $false,
+
+    [ValidateSet("sidecar", "ambient", "none")]
+    [string]$DataplaneMode = "sidecar",
+
+    [switch]$InstallIngressGateway = $false,
+
+    [switch]$InstallDashboard = $false,
+
+    [switch]$AllowInternetEgress = $false,
+
+    [string]$IstioNamespace = "istio-system",
+
+    [string]$PlatformNamespace = "platform-dev",
+
+    [string]$IstioVersion = "1.28.2",
+
+    [switch]$UseGitBash = $false
+)
+
+# ==============================================================================
+# STRICT MODE AND ERROR HANDLING
+# ==============================================================================
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Pinned versions for reproducibility
+$GATEWAY_API_VERSION = "v1.2.1"
+$GATEWAY_API_CRD_URL = "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+
+# ==============================================================================
+# HELPER FUNCTIONS
+# ==============================================================================
+
+function Write-Header {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host ("=" * 70) -ForegroundColor Cyan
+    Write-Host $Message -ForegroundColor Cyan
+    Write-Host ("=" * 70) -ForegroundColor Cyan
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "[STEP] $Message" -ForegroundColor Green
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Gray
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[OK] $Message" -ForegroundColor Green
+}
+
+function Test-Command {
+    param([string]$Command)
+    $null = Get-Command $Command -ErrorAction SilentlyContinue
+    return $?
+}
+
+function Exit-WithError {
+    param(
+        [string]$Message,
+        [string]$Remediation = ""
+    )
+    Write-Err $Message
+    if ($Remediation) {
+        Write-Host "Remediation: $Remediation" -ForegroundColor Yellow
+    }
+    exit 1
+}
+
+function Get-ScriptRoot {
+    # Compatible with PS 5.1 and PS 7+
+    if ($PSScriptRoot) {
+        return $PSScriptRoot
+    }
+    return Split-Path -Parent $MyInvocation.MyCommand.Definition
+}
+
+function Get-RepoRoot {
+    $scriptDir = Get-ScriptRoot
+    # scripts/ is one level below repo root
+    return Split-Path -Parent $scriptDir
+}
+
+function Invoke-KubectlSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$PassThru,
+        [switch]$AllowFailure
+    )
+    
+    $argString = $Arguments -join " "
+    Write-Info "kubectl $argString"
+    
+    if ($PassThru) {
+        $result = & kubectl @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "kubectl command failed: kubectl $argString" "Check cluster connectivity and resource state."
+        }
+        return $result
+    }
+    else {
+        & kubectl @Arguments
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "kubectl command failed: kubectl $argString" "Check cluster connectivity and resource state."
+        }
+    }
+}
+
+function Invoke-HelmSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$PassThru,
+        [switch]$AllowFailure
+    )
+    
+    $argString = $Arguments -join " "
+    Write-Info "helm $argString"
+    
+    if ($PassThru) {
+        $result = & helm @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "helm command failed: helm $argString" "Check Helm configuration and chart availability."
+        }
+        return $result
+    }
+    else {
+        & helm @Arguments
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "helm command failed: helm $argString" "Check Helm configuration and chart availability."
+        }
+    }
+}
+
+function Test-NamespaceExists {
+    param([string]$Namespace)
+    $result = kubectl get namespace $Namespace --ignore-not-found -o name 2>$null
+    return ($null -ne $result -and $result -ne "")
+}
+
+function New-NamespaceIfMissing {
+    param([string]$Namespace)
+    if (-not (Test-NamespaceExists $Namespace)) {
+        Write-Step "Creating namespace: $Namespace"
+        Invoke-KubectlSafe -Arguments @("create", "namespace", $Namespace)
+    }
+    else {
+        Write-Info "Namespace already exists: $Namespace"
+    }
+}
+
+function Get-InstalledIstioVersion {
+    # Check istiod deployment for version label
+    $version = kubectl get deployment istiod -n $IstioNamespace -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and $version) {
+        return $version
+    }
+    
+    # Fallback: check Helm release
+    $releases = helm list -n $IstioNamespace -o json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if ($releases) {
+        $istiod = $releases | Where-Object { $_.name -eq "istiod" }
+        if ($istiod) {
+            # Chart version format: istiod-1.28.2
+            if ($istiod.chart -match "istiod-(.+)") {
+                return $Matches[1]
+            }
+        }
+    }
+    
+    return $null
+}
+
+function Test-HelmReleaseExists {
+    param(
+        [string]$ReleaseName,
+        [string]$Namespace
+    )
+    $result = helm status $ReleaseName -n $Namespace 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# ==============================================================================
+# PRE-FLIGHT CHECKS
+# ==============================================================================
+
+Write-Header "Docker Desktop Kubernetes Bootstrap"
+Write-Host "Istio Version: $IstioVersion"
+Write-Host "Dataplane Mode: $DataplaneMode"
+Write-Host "Platform Namespace: $PlatformNamespace"
+Write-Host "Install Ingress Gateway: $InstallIngressGateway"
+Write-Host "Install Dashboard: $InstallDashboard"
+Write-Host "Allow Internet Egress: $AllowInternetEgress"
+Write-Host ""
+
+# -----------------------------------------------------------------------------
+# Check 1: kubectl exists
+# -----------------------------------------------------------------------------
+Write-Step "Checking for kubectl..."
+if (-not (Test-Command "kubectl")) {
+    Exit-WithError "kubectl not found in PATH." "Install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/"
+}
+Write-Success "kubectl found"
+
+# -----------------------------------------------------------------------------
+# Check 2: helm exists
+# -----------------------------------------------------------------------------
+Write-Step "Checking for helm..."
+if (-not (Test-Command "helm")) {
+    Exit-WithError "helm not found in PATH." "Install helm: https://helm.sh/docs/intro/install/ or 'choco install kubernetes-helm'"
+}
+Write-Success "helm found"
+
+# -----------------------------------------------------------------------------
+# Check 3: Docker Desktop Kubernetes is running
+# -----------------------------------------------------------------------------
+Write-Step "Checking Kubernetes cluster connectivity..."
+$clusterInfo = kubectl cluster-info 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Exit-WithError "Cannot connect to Kubernetes cluster." @"
+Ensure Docker Desktop is running and Kubernetes is enabled:
+1. Open Docker Desktop
+2. Go to Settings > Kubernetes
+3. Check 'Enable Kubernetes'
+4. Click 'Apply & Restart'
+"@
+}
+Write-Success "Kubernetes cluster is reachable"
+
+# -----------------------------------------------------------------------------
+# Check 4: kubecontext is docker-desktop
+# -----------------------------------------------------------------------------
+Write-Step "Checking kubecontext..."
+$currentContext = kubectl config current-context 2>$null
+if ($currentContext -ne "docker-desktop") {
+    if ($Force) {
+        Write-Warn "Current context is '$currentContext', not 'docker-desktop'. Proceeding due to -Force flag."
+        Write-Warn "THIS MAY AFFECT A NON-LOCAL CLUSTER. Use with caution!"
+    }
+    else {
+        Exit-WithError "Current kubecontext is '$currentContext', expected 'docker-desktop'." @"
+Switch context with:
+    kubectl config use-context docker-desktop
+
+Or run with -Force to bypass this safety check (NOT RECOMMENDED for remote clusters).
+"@
+    }
+}
+else {
+    Write-Success "kubecontext is docker-desktop"
+}
+
+# -----------------------------------------------------------------------------
+# Check 5: Default StorageClass exists
+# -----------------------------------------------------------------------------
+Write-Step "Checking StorageClass availability..."
+$storageClasses = kubectl get storageclass -o name 2>$null
+if (-not $storageClasses) {
+    Write-Warn "No StorageClass found. PVC provisioning may fail."
+    Write-Host @"
+Docker Desktop should provide 'hostpath' StorageClass by default.
+If PVCs fail to provision:
+1. Reset Docker Desktop Kubernetes (Settings > Kubernetes > Reset)
+2. Or manually create a StorageClass
+
+Continuing anyway - this may cause issues with PersistentVolumeClaims.
+"@ -ForegroundColor Yellow
+}
+else {
+    $defaultSC = kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>$null
+    if ($defaultSC) {
+        Write-Success "Default StorageClass found: $defaultSC"
+    }
+    else {
+        Write-Warn "StorageClasses exist but none marked as default. PVCs without explicit storageClassName may fail."
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Check 6: Existing Istio version check
+# -----------------------------------------------------------------------------
+Write-Step "Checking for existing Istio installation..."
+$installedVersion = Get-InstalledIstioVersion
+if ($installedVersion) {
+    if ($installedVersion -ne $IstioVersion) {
+        Exit-WithError "Istio version mismatch! Installed: $installedVersion, Required: $IstioVersion" @"
+This script requires Istio $IstioVersion exactly.
+
+To resolve:
+1. OPTION A - Remove existing Istio (if safe):
+   helm uninstall istiod -n $IstioNamespace
+   helm uninstall istio-base -n $IstioNamespace
+   # If ztunnel installed:
+   helm uninstall ztunnel -n $IstioNamespace
+   # If gateway installed:
+   helm uninstall istio-ingressgateway -n $IstioNamespace
+   kubectl delete namespace $IstioNamespace
+
+2. OPTION B - Update this script's IstioVersion parameter to match installed version.
+   (Not recommended - may cause compatibility issues)
+
+3. OPTION C - Reset Docker Desktop Kubernetes entirely:
+   Docker Desktop > Settings > Kubernetes > Reset Kubernetes Cluster
+"@
+    }
+    else {
+        Write-Success "Istio $IstioVersion already installed - will reconcile state"
+    }
+}
+else {
+    Write-Info "No existing Istio installation detected - will install fresh"
+}
+
+# ==============================================================================
+# GATEWAY API CRD INSTALLATION
+# ==============================================================================
+
+Write-Header "Gateway API CRDs"
+
+Write-Step "Checking Gateway API CRDs..."
+$gatewayApiInstalled = kubectl get crd gateways.gateway.networking.k8s.io --ignore-not-found -o name 2>$null
+if (-not $gatewayApiInstalled) {
+    Write-Step "Installing Gateway API CRDs ($GATEWAY_API_VERSION)..."
+    Invoke-KubectlSafe -Arguments @("apply", "-f", $GATEWAY_API_CRD_URL)
+    Write-Success "Gateway API CRDs installed (version $GATEWAY_API_VERSION)"
+}
+else {
+    Write-Success "Gateway API CRDs already installed"
+}
+
+# ==============================================================================
+# HELM REPOSITORY SETUP
+# ==============================================================================
+
+Write-Header "Helm Repository Setup"
+
+Write-Step "Adding Istio Helm repository..."
+Invoke-HelmSafe -Arguments @("repo", "add", "istio", "https://istio-release.storage.googleapis.com/charts") -AllowFailure
+# Repo add fails if exists - that's fine
+
+Write-Step "Updating Helm repositories..."
+Invoke-HelmSafe -Arguments @("repo", "update")
+Write-Success "Helm repositories updated"
+
+# ==============================================================================
+# ISTIO INSTALLATION
+# ==============================================================================
+
+Write-Header "Istio $IstioVersion Installation"
+
+# Create istio-system namespace
+New-NamespaceIfMissing $IstioNamespace
+
+# -----------------------------------------------------------------------------
+# Install istio-base (CRDs and cluster-wide resources)
+# -----------------------------------------------------------------------------
+Write-Step "Installing/upgrading istio-base..."
+Invoke-HelmSafe -Arguments @(
+    "upgrade", "--install", "istio-base", "istio/base",
+    "-n", $IstioNamespace,
+    "--version", $IstioVersion,
+    "--wait"
+)
+Write-Success "istio-base installed"
+
+# -----------------------------------------------------------------------------
+# Install istiod (control plane)
+# -----------------------------------------------------------------------------
+Write-Step "Installing/upgrading istiod..."
+
+# Build istiod values based on dataplane mode
+$istiodValues = @()
+
+# Common values for both modes
+$istiodValues += "--set", "pilot.resources.requests.cpu=100m"
+$istiodValues += "--set", "pilot.resources.requests.memory=256Mi"
+
+# Mode-specific configuration
+switch ($DataplaneMode) {
+    "ambient" {
+        Write-Info "Configuring istiod for Ambient mode..."
+        # Enable ambient mesh support in istiod
+        $istiodValues += "--set", "pilot.env.PILOT_ENABLE_AMBIENT=true"
+        $istiodValues += "--set", "meshConfig.defaultConfig.proxyMetadata.ISTIO_META_ENABLE_HBONE=true"
+    }
+    "sidecar" {
+        Write-Info "Configuring istiod for Sidecar mode..."
+        # Standard sidecar mode - default configuration
+    }
+    "none" {
+        Write-Info "Configuring istiod (no automatic enrollment)..."
+    }
+}
+
+$istiodArgs = @(
+    "upgrade", "--install", "istiod", "istio/istiod",
+    "-n", $IstioNamespace,
+    "--version", $IstioVersion
+) + $istiodValues + @("--wait", "--timeout", "5m")
+
+Invoke-HelmSafe -Arguments $istiodArgs
+Write-Success "istiod installed"
+
+# -----------------------------------------------------------------------------
+# Install ztunnel (Ambient mode only)
+# -----------------------------------------------------------------------------
+if ($DataplaneMode -eq "ambient") {
+    Write-Step "Installing/upgrading ztunnel for Ambient mode..."
+    Invoke-HelmSafe -Arguments @(
+        "upgrade", "--install", "ztunnel", "istio/ztunnel",
+        "-n", $IstioNamespace,
+        "--version", $IstioVersion,
+        "--wait", "--timeout", "3m"
+    )
+    Write-Success "ztunnel installed"
+}
+else {
+    Write-Info "Skipping ztunnel (not required for $DataplaneMode mode)"
+}
+
+# -----------------------------------------------------------------------------
+# Install Ingress Gateway (optional)
+# -----------------------------------------------------------------------------
+if ($InstallIngressGateway) {
+    Write-Step "Installing/upgrading Istio Ingress Gateway..."
+    
+    # For Docker Desktop, use LoadBalancer (maps to localhost) or NodePort
+    Invoke-HelmSafe -Arguments @(
+        "upgrade", "--install", "istio-ingressgateway", "istio/gateway",
+        "-n", $IstioNamespace,
+        "--version", $IstioVersion,
+        "--set", "service.type=LoadBalancer",
+        "--wait", "--timeout", "3m"
+    )
+    Write-Success "Istio Ingress Gateway installed"
+    
+    # Get gateway service info
+    Write-Info "Ingress Gateway service:"
+    kubectl get svc istio-ingressgateway -n $IstioNamespace
+}
+else {
+    Write-Info "Skipping Ingress Gateway (use -InstallIngressGateway to enable)"
+}
+
+# Wait for Istio control plane to be ready
+Write-Step "Waiting for Istio control plane pods..."
+Invoke-KubectlSafe -Arguments @(
+    "wait", "--for=condition=Ready", "pod",
+    "-l", "app=istiod",
+    "-n", $IstioNamespace,
+    "--timeout=120s"
+)
+Write-Success "Istio control plane is ready"
+
+# ==============================================================================
+# PLATFORM NAMESPACE SETUP
+# ==============================================================================
+
+Write-Header "Platform Namespace Setup"
+
+# Create platform namespace
+New-NamespaceIfMissing $PlatformNamespace
+
+# -----------------------------------------------------------------------------
+# Label namespace according to DataplaneMode
+# -----------------------------------------------------------------------------
+Write-Step "Labeling namespace $PlatformNamespace for $DataplaneMode mode..."
+
+switch ($DataplaneMode) {
+    "sidecar" {
+        # Enable sidecar injection
+        Invoke-KubectlSafe -Arguments @(
+            "label", "namespace", $PlatformNamespace,
+            "istio-injection=enabled",
+            "--overwrite"
+        )
+        # Remove ambient label if present
+        Invoke-KubectlSafe -Arguments @(
+            "label", "namespace", $PlatformNamespace,
+            "istio.io/dataplane-mode-",
+            "--overwrite"
+        ) -AllowFailure
+        Write-Success "Namespace labeled for sidecar injection"
+    }
+    "ambient" {
+        # Enable ambient mode
+        Invoke-KubectlSafe -Arguments @(
+            "label", "namespace", $PlatformNamespace,
+            "istio.io/dataplane-mode=ambient",
+            "--overwrite"
+        )
+        # Remove sidecar injection label if present
+        Invoke-KubectlSafe -Arguments @(
+            "label", "namespace", $PlatformNamespace,
+            "istio-injection-",
+            "--overwrite"
+        ) -AllowFailure
+        Write-Success "Namespace labeled for ambient mode"
+    }
+    "none" {
+        # Remove both labels
+        Invoke-KubectlSafe -Arguments @(
+            "label", "namespace", $PlatformNamespace,
+            "istio-injection-",
+            "istio.io/dataplane-mode-",
+            "--overwrite"
+        ) -AllowFailure
+        Write-Success "Namespace has no Istio enrollment"
+    }
+}
+
+# ==============================================================================
+# SECURITY MANIFESTS
+# ==============================================================================
+
+Write-Header "Security Policies"
+
+$repoRoot = Get-RepoRoot
+$securityPath = Join-Path $repoRoot "k8s/dev/security"
+$networkPolicyPath = Join-Path $repoRoot "k8s/dev/networkpolicies"
+$ambientPath = Join-Path $repoRoot "k8s/dev/ambient"
+
+# Verify manifest directories exist
+if (-not (Test-Path $securityPath)) {
+    Exit-WithError "Security manifests not found at: $securityPath" "Ensure k8s/dev/security/ directory exists in repo."
+}
+if (-not (Test-Path $networkPolicyPath)) {
+    Exit-WithError "NetworkPolicy manifests not found at: $networkPolicyPath" "Ensure k8s/dev/networkpolicies/ directory exists in repo."
+}
+
+# -----------------------------------------------------------------------------
+# Always apply: Zero Trust base policies
+# -----------------------------------------------------------------------------
+Write-Step "Applying PeerAuthentication (mTLS STRICT)..."
+Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $securityPath "peerauthentication-strict.yaml"))
+
+Write-Step "Applying AuthorizationPolicy (default-deny)..."
+Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $securityPath "authz-default-deny.yaml"))
+
+Write-Step "Applying AuthorizationPolicy (allow intra-namespace)..."
+Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $securityPath "authz-allow-intra-namespace.yaml"))
+
+Write-Step "Applying NetworkPolicy (default-deny)..."
+Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $networkPolicyPath "np-default-deny.yaml"))
+
+Write-Step "Applying NetworkPolicy (allow DNS)..."
+Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $networkPolicyPath "np-allow-dns.yaml"))
+
+Write-Success "Zero Trust base policies applied"
+
+# -----------------------------------------------------------------------------
+# Conditional: Ingress Gateway authorization
+# -----------------------------------------------------------------------------
+if ($InstallIngressGateway) {
+    Write-Step "Applying AuthorizationPolicy (allow from ingress gateway)..."
+    Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $securityPath "authz-allow-from-ingressgateway.yaml"))
+    Write-Success "Ingress gateway authorization policy applied"
+}
+else {
+    Write-Info "Skipping ingress gateway auth policy (gateway not installed)"
+}
+
+# -----------------------------------------------------------------------------
+# Conditional: Internet egress
+# -----------------------------------------------------------------------------
+if ($AllowInternetEgress) {
+    Write-Step "Applying NetworkPolicy (allow internet egress)..."
+    Invoke-KubectlSafe -Arguments @("apply", "-f", (Join-Path $networkPolicyPath "np-allow-internet-egress.yaml"))
+    Write-Success "Internet egress NetworkPolicy applied"
+}
+else {
+    Write-Info "Internet egress blocked (default). Use -AllowInternetEgress to enable."
+}
+
+# -----------------------------------------------------------------------------
+# Ambient mode: Waypoint deployment
+# -----------------------------------------------------------------------------
+if ($DataplaneMode -eq "ambient") {
+    Write-Header "Ambient Mode: Waypoint Proxy"
+    
+    $waypointManifest = Join-Path $ambientPath "waypoint-platform-dev.yaml"
+    
+    if (Test-Path $waypointManifest) {
+        Write-Step "Applying Waypoint proxy for L7 traffic management..."
+        Invoke-KubectlSafe -Arguments @("apply", "-f", $waypointManifest)
+        Write-Success "Waypoint proxy deployed"
+        
+        Write-Info @"
+
+IMPORTANT: Waypoint enables L7 features in Ambient mode.
+Without waypoint, only L4 (mTLS, basic allow/deny) is available.
+With waypoint, you get: request routing, retries, timeouts, header matching.
+
+To verify waypoint:
+    kubectl get gateway -n $PlatformNamespace
+    kubectl get pods -n $PlatformNamespace -l gateway.networking.k8s.io/gateway-name=waypoint
+
+"@
+    }
+    else {
+        Write-Warn "Waypoint manifest not found at: $waypointManifest"
+        Write-Host @"
+
+To manually apply waypoint for L7 features:
+    kubectl apply -f k8s/dev/ambient/waypoint-platform-dev.yaml
+
+Or use istioctl:
+    istioctl waypoint apply -n $PlatformNamespace --name waypoint
+
+"@ -ForegroundColor Yellow
+    }
+}
+
+# ==============================================================================
+# KUBERNETES DASHBOARD (Optional)
+# ==============================================================================
+
+if ($InstallDashboard) {
+    Write-Header "Kubernetes Dashboard"
+    
+    Write-Step "Adding Kubernetes Dashboard Helm repository..."
+    Invoke-HelmSafe -Arguments @("repo", "add", "kubernetes-dashboard", "https://kubernetes.github.io/dashboard/") -AllowFailure
+    Invoke-HelmSafe -Arguments @("repo", "update")
+    
+    Write-Step "Installing/upgrading Kubernetes Dashboard..."
+    Invoke-HelmSafe -Arguments @(
+        "upgrade", "--install", "kubernetes-dashboard", "kubernetes-dashboard/kubernetes-dashboard",
+        "-n", "kubernetes-dashboard",
+        "--create-namespace",
+        "--wait", "--timeout", "3m"
+    )
+    Write-Success "Kubernetes Dashboard installed"
+    
+    Write-Host @"
+
+DASHBOARD ACCESS:
+-----------------
+Run this command to start port forwarding (Ctrl+C to stop):
+    kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+
+Then open: https://localhost:8443
+
+AUTHENTICATION:
+For basic exploration, create a service account with view permissions:
+    kubectl create serviceaccount dashboard-viewer -n kubernetes-dashboard
+    kubectl create clusterrolebinding dashboard-viewer --clusterrole=view --serviceaccount=kubernetes-dashboard:dashboard-viewer
+    kubectl create token dashboard-viewer -n kubernetes-dashboard
+
+WARNING: Do NOT create cluster-admin tokens for the dashboard in production.
+Use RBAC to grant minimum necessary permissions.
+
+"@ -ForegroundColor Cyan
+}
+
+# ==============================================================================
+# VERIFICATION
+# ==============================================================================
+
+Write-Header "Verification"
+
+Write-Step "Istio system pods:"
+kubectl get pods -n $IstioNamespace
+
+Write-Host ""
+Write-Step "Platform namespace pods:"
+kubectl get pods -n $PlatformNamespace 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Info "No pods in $PlatformNamespace yet (expected for fresh setup)"
+}
+
+Write-Host ""
+Write-Step "Helm releases in $IstioNamespace"
+helm list -n $IstioNamespace
+
+Write-Host ""
+Write-Step "Namespace labels:"
+kubectl get namespace $PlatformNamespace -o jsonpath='{.metadata.labels}' | ConvertFrom-Json | Format-List
+
+Write-Host ""
+Write-Step "Applied security policies:"
+Write-Info "PeerAuthentication:"
+kubectl get peerauthentication -n $PlatformNamespace 2>$null
+Write-Info "AuthorizationPolicy:"
+kubectl get authorizationpolicy -n $PlatformNamespace 2>$null
+Write-Info "NetworkPolicy:"
+kubectl get networkpolicy -n $PlatformNamespace 2>$null
+
+# Check for istioctl
+if (Test-Command "istioctl") {
+    Write-Host ""
+    Write-Step "Running istioctl verify-install..."
+    istioctl verify-install 2>&1 | Write-Host
+}
+else {
+    Write-Info "istioctl not found - skipping verify-install (optional tool)"
+}
+
+# ==============================================================================
+# SUMMARY
+# ==============================================================================
+
+Write-Header "Bootstrap Complete!"
+
+Write-Host @"
+CONFIGURATION SUMMARY
+---------------------
+Istio Version:        $IstioVersion
+Dataplane Mode:       $DataplaneMode
+Istio Namespace:      $IstioNamespace
+Platform Namespace:   $PlatformNamespace
+Ingress Gateway:      $InstallIngressGateway
+Internet Egress:      $AllowInternetEgress
+Dashboard:            $InstallDashboard
+
+VERIFICATION COMMANDS
+---------------------
+# Check Istio pods
+kubectl get pods -n $IstioNamespace
+
+# Check platform namespace enrollment
+kubectl get namespace $PlatformNamespace --show-labels
+
+# Check mTLS status (requires istioctl)
+istioctl authn tls-check -n $PlatformNamespace
+
+# Test connectivity from a pod
+kubectl run test-curl --rm -it --image=curlimages/curl -n $PlatformNamespace -- curl -v http://<service>
+
+NEXT STEPS
+----------
+1. Deploy your application to $PlatformNamespace
+2. Use Tilt: tilt up -- --mode=k8s --k8s-istio-enabled=true
+3. Access via port-forward or ingress gateway (if enabled)
+
+For production-like routing with gateway:
+    tilt up -- --mode=k8s --k8s-istio-enabled=true --k8s-manage-gateway=true
+
+Documentation: README.md
+"@ -ForegroundColor Green
+
+exit 0

--- a/scripts/teardown-script.ps1
+++ b/scripts/teardown-script.ps1
@@ -1,0 +1,650 @@
+<#
+.SYNOPSIS
+    Idempotent teardown for Docker Desktop Kubernetes bootstrap with Istio service mesh.
+
+.DESCRIPTION
+    Safely removes what our bootstrap script sets up:
+    - Istio Helm releases (istio-base, istiod, optional ztunnel, optional ingress gateway)
+    - Optional Kubernetes Dashboard Helm release
+    - Platform namespace enrollment labels (sidecar/ambient)
+    - Bootstrap-applied security policies and NetworkPolicies (and optional waypoint)
+    - OPTIONAL: Gateway API CRDs (cluster-wide) (opt-in)
+    - OPTIONAL: Namespace deletion (destructive) (opt-in + explicit acknowledgement)
+
+    Designed for Windows 10/11 with PowerShell 5.1+ or PowerShell 7+.
+
+.SAFETY / IDEMPOTENCY
+    - Safe to run multiple times
+    - Does NOT delete workloads or namespaces by default
+    - Does NOT remove Gateway API CRDs by default
+    - Tolerates resources/releases not existing
+    - Fails fast with actionable errors
+
+.PARAMETER Force
+    Bypass kubecontext safety check AND allow teardown even if Istio version != expected.
+
+.PARAMETER IstioNamespace
+    Namespace where Istio control plane is installed (default: istio-system).
+
+.PARAMETER PlatformNamespace
+    Application namespace used by bootstrap (default: platform-dev).
+
+.PARAMETER DashboardNamespace
+    Namespace where Kubernetes Dashboard is installed (default: kubernetes-dashboard).
+
+.PARAMETER IstioVersion
+    Expected Istio version (bootstrap pinned). Used for safety check / reporting.
+
+.PARAMETER RemoveIngressGateway
+    Uninstall istio-ingressgateway Helm release if present (default: true).
+
+.PARAMETER RemoveZtunnel
+    Uninstall ztunnel Helm release if present (default: true).
+
+.PARAMETER RemoveDashboard
+    Uninstall kubernetes-dashboard Helm release if present (default: true).
+
+.PARAMETER RemovePlatformPolicies
+    Delete bootstrap-applied policies/waypoint from repo YAML (default: true).
+
+.PARAMETER RemoveNamespaceLabels
+    Remove namespace labels used for Istio enrollment from PlatformNamespace (default: true).
+
+.PARAMETER DeleteNamespaces
+    DESTRUCTIVE. Delete Platform/Istio/Dashboard namespaces (default: false).
+    Requires -IUnderstandThisDeletesWorkloads.
+
+.PARAMETER IUnderstandThisDeletesWorkloads
+    Required acknowledgement switch when using -DeleteNamespaces.
+
+.PARAMETER RemoveGatewayApiCrds
+    DESTRUCTIVE (cluster-wide). Remove Gateway API CRDs installed by bootstrap (default: false).
+
+.EXAMPLE
+    .\teardown-docker-desktop-k8s.ps1
+    # Removes bootstrap-applied policies, removes labels, uninstalls Istio releases, uninstalls dashboard (if installed).
+    # Does NOT delete namespaces and does NOT remove Gateway API CRDs.
+
+.EXAMPLE
+    .\teardown-docker-desktop-k8s.ps1 -DeleteNamespaces -IUnderstandThisDeletesWorkloads
+    # Also deletes the namespaces (DESTRUCTIVE).
+
+.EXAMPLE
+    .\teardown-docker-desktop-k8s.ps1 -RemoveGatewayApiCrds
+    # Also removes Gateway API CRDs (cluster-wide, opt-in).
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Force = $false,
+
+    [string]$IstioNamespace = "istio-system",
+    [string]$PlatformNamespace = "platform-dev",
+    [string]$DashboardNamespace = "kubernetes-dashboard",
+
+    [string]$IstioVersion = "1.28.2",
+
+    [switch]$RemoveIngressGateway = $true,
+    [switch]$RemoveZtunnel = $true,
+    [switch]$RemoveDashboard = $true,
+
+    [switch]$RemovePlatformPolicies = $true,
+    [switch]$RemoveNamespaceLabels = $true,
+
+    [switch]$DeleteNamespaces = $false,
+    [switch]$IUnderstandThisDeletesWorkloads = $false,
+
+    [switch]$RemoveGatewayApiCrds = $false
+)
+
+# ==============================================================================
+# STRICT MODE AND ERROR HANDLING
+# ==============================================================================
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Gateway API CRDs pinned by bootstrap
+$GATEWAY_API_VERSION = "v1.2.1"
+$GATEWAY_API_CRD_URL = "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+
+# Helm release names used by bootstrap
+$RELEASE_ISTIO_BASE = "istio-base"
+$RELEASE_ISTIOD     = "istiod"
+$RELEASE_ZTUNNEL    = "ztunnel"
+$RELEASE_INGRESS    = "istio-ingressgateway"
+$RELEASE_DASHBOARD  = "kubernetes-dashboard"
+
+# ==============================================================================
+# HELPER FUNCTIONS
+# ==============================================================================
+
+function Write-Header {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host ("=" * 70) -ForegroundColor Cyan
+    Write-Host $Message -ForegroundColor Cyan
+    Write-Host ("=" * 70) -ForegroundColor Cyan
+}
+
+function Write-Step { param([string]$Message) Write-Host "[STEP] $Message" -ForegroundColor Green }
+function Write-Info { param([string]$Message) Write-Host "[INFO] $Message" -ForegroundColor Gray }
+function Write-Warn { param([string]$Message) Write-Host "[WARN] $Message" -ForegroundColor Yellow }
+function Write-Err  { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red }
+function Write-OK   { param([string]$Message) Write-Host "[OK] $Message" -ForegroundColor Green }
+
+function Exit-WithError {
+    param(
+        [string]$Message,
+        [string]$Remediation = ""
+    )
+    Write-Err $Message
+    if ($Remediation) {
+        Write-Host "Remediation: $Remediation" -ForegroundColor Yellow
+    }
+    exit 1
+}
+
+function Test-Command {
+    param([string]$Command)
+    $null = Get-Command $Command -ErrorAction SilentlyContinue
+    return $?
+}
+
+function Get-ScriptRoot {
+    # Compatible with PS 5.1 and PS 7+
+    if ($PSScriptRoot) { return $PSScriptRoot }
+    return Split-Path -Parent $MyInvocation.MyCommand.Definition
+}
+
+function Get-RepoRoot {
+    $scriptDir = Get-ScriptRoot
+    return Split-Path -Parent $scriptDir
+}
+
+function Invoke-KubectlSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$PassThru,
+        [switch]$AllowFailure
+    )
+
+    $argString = $Arguments -join " "
+    Write-Info "kubectl $argString"
+
+    if ($PassThru) {
+        $result = & kubectl @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "kubectl command failed: kubectl $argString" "Check cluster connectivity and resource state."
+        }
+        return $result
+    } else {
+        & kubectl @Arguments
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "kubectl command failed: kubectl $argString" "Check cluster connectivity and resource state."
+        }
+    }
+}
+
+function Invoke-HelmSafe {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments,
+        [switch]$PassThru,
+        [switch]$AllowFailure
+    )
+
+    $argString = $Arguments -join " "
+    Write-Info "helm $argString"
+
+    if ($PassThru) {
+        $result = & helm @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "helm command failed: helm $argString" "Check Helm configuration and cluster state."
+        }
+        return $result
+    } else {
+        & helm @Arguments
+        if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+            Exit-WithError "helm command failed: helm $argString" "Check Helm configuration and cluster state."
+        }
+    }
+}
+
+function Test-NamespaceExists {
+    param([string]$Namespace)
+    $result = & kubectl get namespace $Namespace --ignore-not-found -o name 2>$null
+    return ($LASTEXITCODE -eq 0 -and $null -ne $result -and $result -ne "")
+}
+
+function Test-HelmReleaseExists {
+    param(
+        [string]$ReleaseName,
+        [string]$Namespace
+    )
+    $null = & helm status $ReleaseName -n $Namespace 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Get-InstalledIstioVersion {
+    # Try deployment label first
+    $version = & kubectl get deployment istiod -n $IstioNamespace -o jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and $version) { return $version }
+
+    # Fallback to Helm chart name parsing
+    $json = & helm list -n $IstioNamespace -o json 2>$null
+    if ($LASTEXITCODE -eq 0 -and $json) {
+        try {
+            $releases = $json | ConvertFrom-Json -ErrorAction Stop
+            $istiod = $releases | Where-Object { $_.name -eq $RELEASE_ISTIOD }
+            if ($istiod -and $istiod.chart -match "istiod-(.+)") {
+                return $Matches[1]
+            }
+        } catch {
+            # Ignore JSON parse issues; just return null
+        }
+    }
+    return $null
+}
+
+function Remove-HelmReleaseIfPresent {
+    param(
+        [Parameter(Mandatory)][string]$ReleaseName,
+        [Parameter(Mandatory)][string]$Namespace
+    )
+
+    if (Test-HelmReleaseExists -ReleaseName $ReleaseName -Namespace $Namespace) {
+        Write-Step "Uninstalling Helm release '$ReleaseName' in namespace '$Namespace'..."
+        Invoke-HelmSafe -Arguments @("uninstall", $ReleaseName, "-n", $Namespace)
+        Write-OK "Uninstalled '$ReleaseName'"
+    } else {
+        Write-Info "Helm release '$ReleaseName' not found in '$Namespace' (nothing to do)"
+    }
+}
+
+function Remove-NamespaceLabel {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$LabelKey
+    )
+
+    if (-not (Test-NamespaceExists $Namespace)) {
+        Write-Info "Namespace '$Namespace' does not exist; skipping label removal '$LabelKey-'"
+        return
+    }
+
+    # Removing a label uses the "key-" syntax
+    Invoke-KubectlSafe -Arguments @(
+        "label", "namespace", $Namespace,
+        ("{0}-" -f $LabelKey),
+        "--overwrite"
+    ) -AllowFailure
+
+    Write-OK "Removed label '$LabelKey' from namespace '$Namespace' (if it existed)"
+}
+
+function Delete-FromFileIfExists {
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string]$FriendlyName
+    )
+
+    if (Test-Path $FilePath) {
+        Write-Step "Deleting $FriendlyName from file: $FilePath"
+        Invoke-KubectlSafe -Arguments @("delete", "-f", $FilePath, "--ignore-not-found=true") -AllowFailure
+        Write-OK "Delete applied for $FriendlyName (file-driven)"
+        return $true
+    } else {
+        Write-Warn "$FriendlyName manifest not found at: $FilePath"
+        return $false
+    }
+}
+
+function BestEffort-DeleteKnownBootstrapResources {
+    param([string]$Namespace)
+
+    # Conservative best-effort deletions by likely names.
+    # These only delete if exact name exists; otherwise they're no-ops due to --ignore-not-found.
+    Write-Warn "Attempting best-effort deletion by likely resource names (because one or more manifest files were missing)."
+    Write-Warn "If this doesn't remove everything, restore the repo manifests and re-run this script."
+
+    # Security policies (Istio)
+    Invoke-KubectlSafe -Arguments @("delete", "peerauthentication", "peerauthentication-strict", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+    Invoke-KubectlSafe -Arguments @("delete", "peerauthentication", "default", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+
+    Invoke-KubectlSafe -Arguments @("delete", "authorizationpolicy", "default-deny", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+    Invoke-KubectlSafe -Arguments @("delete", "authorizationpolicy", "allow-intra-namespace", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+    Invoke-KubectlSafe -Arguments @("delete", "authorizationpolicy", "allow-from-ingressgateway", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+
+    # NetworkPolicies
+    Invoke-KubectlSafe -Arguments @("delete", "networkpolicy", "default-deny", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+    Invoke-KubectlSafe -Arguments @("delete", "networkpolicy", "allow-dns", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+    Invoke-KubectlSafe -Arguments @("delete", "networkpolicy", "allow-internet-egress", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+
+    # Ambient waypoint (Gateway API) - common naming patterns
+    Invoke-KubectlSafe -Arguments @("delete", "gateway", "waypoint", "-n", $Namespace, "--ignore-not-found=true") -AllowFailure
+
+    Write-OK "Best-effort deletion attempted"
+}
+
+function Delete-NamespaceIfRequested {
+    param([string]$Namespace)
+
+    if (-not (Test-NamespaceExists $Namespace)) {
+        Write-Info "Namespace '$Namespace' not found (nothing to delete)"
+        return
+    }
+
+    Write-Step "Deleting namespace '$Namespace' (DESTRUCTIVE)..."
+    Invoke-KubectlSafe -Arguments @("delete", "namespace", $Namespace, "--ignore-not-found=true") -AllowFailure
+
+    # Waiting for namespace deletion can take time; allow failure if it races.
+    Invoke-KubectlSafe -Arguments @("wait", "--for=delete", ("namespace/{0}" -f $Namespace), "--timeout=180s") -AllowFailure
+    Write-OK "Namespace deletion requested: '$Namespace'"
+}
+
+# ==============================================================================
+# PRE-FLIGHT CHECKS
+# ==============================================================================
+
+Write-Header "Docker Desktop Kubernetes Teardown (Istio + Policies)"
+
+Write-Step "Checking for kubectl..."
+if (-not (Test-Command "kubectl")) {
+    Exit-WithError "kubectl not found in PATH." "Install kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/"
+}
+Write-OK "kubectl found"
+
+Write-Step "Checking for helm..."
+if (-not (Test-Command "helm")) {
+    Exit-WithError "helm not found in PATH." "Install helm: https://helm.sh/docs/intro/install/ or 'choco install kubernetes-helm'"
+}
+Write-OK "helm found"
+
+Write-Step "Checking Kubernetes cluster connectivity..."
+$clusterInfo = & kubectl cluster-info 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Exit-WithError "Cannot connect to Kubernetes cluster." "Ensure Docker Desktop is running and Kubernetes is enabled."
+}
+Write-OK "Kubernetes cluster is reachable"
+
+Write-Step "Checking kubecontext..."
+$currentContext = & kubectl config current-context 2>$null
+if ($currentContext -ne "docker-desktop") {
+    if ($Force) {
+        Write-Warn "Current context is '$currentContext', not 'docker-desktop'. Proceeding due to -Force."
+        Write-Warn "THIS MAY AFFECT A NON-LOCAL CLUSTER. Use with caution!"
+    } else {
+        Exit-WithError "Current kubecontext is '$currentContext', expected 'docker-desktop'." @"
+Switch context with:
+    kubectl config use-context docker-desktop
+
+Or run with -Force to bypass this safety check (NOT RECOMMENDED for remote clusters).
+"@
+    }
+} else {
+    Write-OK "kubecontext is docker-desktop"
+}
+
+# Safety: Istio version mismatch handling
+Write-Step "Checking existing Istio installation/version (safety)..."
+$installedIstioVersion = Get-InstalledIstioVersion
+if ($installedIstioVersion) {
+    Write-Info "Detected Istio version: $installedIstioVersion (expected bootstrap version: $IstioVersion)"
+    if ($installedIstioVersion -ne $IstioVersion -and -not $Force) {
+        Exit-WithError "Istio version mismatch detected. Refusing teardown without -Force." @"
+Installed: $installedIstioVersion
+Expected:  $IstioVersion
+
+If this cluster has a different Istio version installed intentionally, re-run with:
+    .\teardown-docker-desktop-k8s.ps1 -Force
+
+NOTE: This script uninstalls Istio Helm releases by name; ensure that is desired.
+"@
+    }
+} else {
+    Write-Info "Istio not detected (or istiod deployment missing). Teardown will still attempt release cleanup safely."
+}
+
+# Destructive flag guard
+if ($DeleteNamespaces -and -not $IUnderstandThisDeletesWorkloads) {
+    Exit-WithError "-DeleteNamespaces is DESTRUCTIVE and requires -IUnderstandThisDeletesWorkloads." @"
+Example:
+    .\teardown-docker-desktop-k8s.ps1 -DeleteNamespaces -IUnderstandThisDeletesWorkloads
+
+This will delete workloads in:
+- $PlatformNamespace
+- $IstioNamespace
+- $DashboardNamespace (if present)
+"@
+}
+
+# ==============================================================================
+# PLAN (PRINT BEFORE EXECUTION)
+# ==============================================================================
+
+Write-Header "Plan"
+
+Write-Host "Target context:             $currentContext"
+Write-Host "Istio namespace:            $IstioNamespace"
+Write-Host "Platform namespace:         $PlatformNamespace"
+Write-Host "Dashboard namespace:        $DashboardNamespace"
+Write-Host "Expected Istio version:     $IstioVersion"
+Write-Host ""
+Write-Host "RemovePlatformPolicies:     $RemovePlatformPolicies"
+Write-Host "RemoveNamespaceLabels:      $RemoveNamespaceLabels"
+Write-Host "RemoveIngressGateway:       $RemoveIngressGateway"
+Write-Host "RemoveZtunnel:              $RemoveZtunnel"
+Write-Host "RemoveDashboard:            $RemoveDashboard"
+Write-Host "RemoveGatewayApiCrds:       $RemoveGatewayApiCrds  (CLUSTER-WIDE)"
+Write-Host "DeleteNamespaces:           $DeleteNamespaces       (DESTRUCTIVE)"
+if ($DeleteNamespaces) {
+    Write-Host "IUnderstandThisDeletesWorkloads: $IUnderstandThisDeletesWorkloads" -ForegroundColor Yellow
+}
+Write-Host ""
+
+if ($RemoveGatewayApiCrds) {
+    Write-Warn "Gateway API CRDs removal is cluster-wide and may break other apps/controllers."
+}
+if ($DeleteNamespaces) {
+    Write-Warn "Namespace deletion will delete workloads and all namespaced resources in those namespaces."
+}
+
+# ==============================================================================
+# PLATFORM POLICIES / WAYPOINT REMOVAL
+# ==============================================================================
+
+$missingAnyManifests = $false
+
+if ($RemovePlatformPolicies) {
+    Write-Header "Remove Bootstrap-Applied Policies (Platform Namespace)"
+
+    if (-not (Test-NamespaceExists $PlatformNamespace)) {
+        Write-Warn "Platform namespace '$PlatformNamespace' does not exist. Skipping file-driven policy deletion."
+    } else {
+        $repoRoot = Get-RepoRoot
+
+        $securityPath      = Join-Path $repoRoot "k8s/dev/security"
+        $networkPolicyPath = Join-Path $repoRoot "k8s/dev/networkpolicies"
+        $ambientPath       = Join-Path $repoRoot "k8s/dev/ambient"
+
+        # Waypoint first (ambient)
+        $waypointFile = Join-Path $ambientPath "waypoint-platform-dev.yaml"
+        $ok = Delete-FromFileIfExists -FilePath $waypointFile -FriendlyName "Waypoint (Ambient)"
+        if (-not $ok) { $missingAnyManifests = $true }
+
+        # Security policies
+        $files = @(
+            @{ Path = (Join-Path $securityPath "peerauthentication-strict.yaml"); Friendly = "PeerAuthentication (mTLS STRICT)" },
+            @{ Path = (Join-Path $securityPath "authz-default-deny.yaml");          Friendly = "AuthorizationPolicy (default-deny)" },
+            @{ Path = (Join-Path $securityPath "authz-allow-intra-namespace.yaml"); Friendly = "AuthorizationPolicy (allow intra-namespace)" },
+            @{ Path = (Join-Path $securityPath "authz-allow-from-ingressgateway.yaml"); Friendly = "AuthorizationPolicy (allow from ingress gateway)" } # optional usage
+        )
+
+        foreach ($f in $files) {
+            $ok = Delete-FromFileIfExists -FilePath $f.Path -FriendlyName $f.Friendly
+            if (-not $ok) { $missingAnyManifests = $true }
+        }
+
+        # NetworkPolicies
+        $npFiles = @(
+            @{ Path = (Join-Path $networkPolicyPath "np-default-deny.yaml");         Friendly = "NetworkPolicy (default-deny)" },
+            @{ Path = (Join-Path $networkPolicyPath "np-allow-dns.yaml");            Friendly = "NetworkPolicy (allow DNS)" },
+            @{ Path = (Join-Path $networkPolicyPath "np-allow-internet-egress.yaml");Friendly = "NetworkPolicy (allow internet egress)" } # optional usage
+        )
+
+        foreach ($f in $npFiles) {
+            $ok = Delete-FromFileIfExists -FilePath $f.Path -FriendlyName $f.Friendly
+            if (-not $ok) { $missingAnyManifests = $true }
+        }
+
+        if ($missingAnyManifests) {
+            Write-Warn "One or more manifest files were missing. This usually means you're not running from the repo, or manifests were moved/deleted."
+            Write-Host "Remediation:" -ForegroundColor Yellow
+            Write-Host "  - Run this script from the repo after restoring k8s/dev/** manifests." -ForegroundColor Yellow
+            Write-Host "  - Repo root should contain: k8s/dev/security, k8s/dev/networkpolicies, k8s/dev/ambient" -ForegroundColor Yellow
+
+            BestEffort-DeleteKnownBootstrapResources -Namespace $PlatformNamespace
+        } else {
+            Write-OK "Policy/waypoint deletion applied via repo manifests"
+        }
+    }
+} else {
+    Write-Info "Skipping platform policy deletion (RemovePlatformPolicies=false)"
+}
+
+# ==============================================================================
+# NAMESPACE LABEL REMOVAL
+# ==============================================================================
+
+if ($RemoveNamespaceLabels) {
+    Write-Header "Remove Platform Namespace Enrollment Labels"
+    Remove-NamespaceLabel -Namespace $PlatformNamespace -LabelKey "istio-injection"
+    Remove-NamespaceLabel -Namespace $PlatformNamespace -LabelKey "istio.io/dataplane-mode"
+} else {
+    Write-Info "Skipping namespace label removal (RemoveNamespaceLabels=false)"
+}
+
+# ==============================================================================
+# ISTIO HELM RELEASE REMOVAL
+# ==============================================================================
+
+Write-Header "Remove Istio Helm Releases"
+
+# Remove gateway and ztunnel first (depend on control plane)
+if ($RemoveIngressGateway) {
+    Remove-HelmReleaseIfPresent -ReleaseName $RELEASE_INGRESS -Namespace $IstioNamespace
+} else {
+    Write-Info "Skipping ingress gateway uninstall (RemoveIngressGateway=false)"
+}
+
+if ($RemoveZtunnel) {
+    Remove-HelmReleaseIfPresent -ReleaseName $RELEASE_ZTUNNEL -Namespace $IstioNamespace
+} else {
+    Write-Info "Skipping ztunnel uninstall (RemoveZtunnel=false)"
+}
+
+# Then control plane and base
+Remove-HelmReleaseIfPresent -ReleaseName $RELEASE_ISTIOD -Namespace $IstioNamespace
+Remove-HelmReleaseIfPresent -ReleaseName $RELEASE_ISTIO_BASE -Namespace $IstioNamespace
+
+# ==============================================================================
+# DASHBOARD REMOVAL
+# ==============================================================================
+
+if ($RemoveDashboard) {
+    Write-Header "Remove Kubernetes Dashboard"
+    Remove-HelmReleaseIfPresent -ReleaseName $RELEASE_DASHBOARD -Namespace $DashboardNamespace
+} else {
+    Write-Info "Skipping dashboard uninstall (RemoveDashboard=false)"
+}
+
+# ==============================================================================
+# GATEWAY API CRD REMOVAL (OPT-IN, CLUSTER-WIDE)
+# ==============================================================================
+
+if ($RemoveGatewayApiCrds) {
+    Write-Header "Remove Gateway API CRDs (CLUSTER-WIDE)"
+    Write-Warn "This removes Gateway API CRDs installed from pinned URL (bootstrap)."
+    Write-Warn "If other apps/controllers depend on Gateway API, they may break."
+
+    Write-Step "Deleting Gateway API CRDs from: $GATEWAY_API_CRD_URL"
+    Invoke-KubectlSafe -Arguments @("delete", "-f", $GATEWAY_API_CRD_URL, "--ignore-not-found=true") -AllowFailure
+    Write-OK "Gateway API CRD delete applied (cluster-wide)"
+} else {
+    Write-Info "Skipping Gateway API CRD removal (RemoveGatewayApiCrds=false)"
+}
+
+# ==============================================================================
+# NAMESPACE DELETION (OPT-IN, DESTRUCTIVE)
+# ==============================================================================
+
+if ($DeleteNamespaces) {
+    Write-Header "Delete Namespaces (DESTRUCTIVE)"
+    Write-Warn "Deleting namespaces will delete workloads and all namespaced resources within them."
+
+    Delete-NamespaceIfRequested -Namespace $PlatformNamespace
+    Delete-NamespaceIfRequested -Namespace $IstioNamespace
+    Delete-NamespaceIfRequested -Namespace $DashboardNamespace
+} else {
+    Write-Info "Skipping namespace deletion (DeleteNamespaces=false)"
+}
+
+# ==============================================================================
+# VERIFICATION
+# ==============================================================================
+
+Write-Header "Verification"
+
+Write-Step "Namespaces:"
+Invoke-KubectlSafe -Arguments @("get", "ns") -AllowFailure
+
+Write-Host ""
+Write-Step "Helm releases (all namespaces):"
+Invoke-HelmSafe -Arguments @("list", "-A") -AllowFailure
+
+Write-Host ""
+Write-Step "Gateway API CRDs (if present):"
+# Use kubectl + jsonpath-ish listing; tolerate absence.
+Invoke-KubectlSafe -Arguments @("get", "crd") -AllowFailure | Out-Null
+# Better: attempt to list specific known CRDs; no-op if missing.
+Invoke-KubectlSafe -Arguments @("get", "crd", "gateways.gateway.networking.k8s.io", "--ignore-not-found") -AllowFailure
+Invoke-KubectlSafe -Arguments @("get", "crd", "httproutes.gateway.networking.k8s.io", "--ignore-not-found") -AllowFailure
+
+Write-Host ""
+Write-Step "Platform namespace labels (if namespace exists):"
+if (Test-NamespaceExists $PlatformNamespace) {
+    Invoke-KubectlSafe -Arguments @("get", "namespace", $PlatformNamespace, "--show-labels") -AllowFailure
+} else {
+    Write-Info "Namespace '$PlatformNamespace' not present"
+}
+
+Write-Host ""
+Write-Step "Bootstrap policy resource kinds in platform namespace (tolerate missing):"
+if (Test-NamespaceExists $PlatformNamespace) {
+    Invoke-KubectlSafe -Arguments @("get", "peerauthentication", "-n", $PlatformNamespace) -AllowFailure
+    Invoke-KubectlSafe -Arguments @("get", "authorizationpolicy", "-n", $PlatformNamespace) -AllowFailure
+    Invoke-KubectlSafe -Arguments @("get", "networkpolicy", "-n", $PlatformNamespace) -AllowFailure
+    Invoke-KubectlSafe -Arguments @("get", "gateway", "-n", $PlatformNamespace) -AllowFailure
+} else {
+    Write-Info "Namespace '$PlatformNamespace' not present"
+}
+
+# ==============================================================================
+# SUMMARY / NEXT STEPS
+# ==============================================================================
+
+Write-Header "Teardown Complete"
+
+Write-Host @"
+- If you want a truly pristine cluster, Docker Desktop can reset Kubernetes:
+  Docker Desktop > Settings > Kubernetes > Reset Kubernetes Cluster
+
+Common checks:
+  kubectl get ns
+  helm list -A
+
+If you removed Istio, workloads previously enrolled may need redeploy/restart to clear sidecars.
+"@ -ForegroundColor Green
+
+exit 0


### PR DESCRIPTION
This commit provides Windows-first, idempotent automation for standing up and reverting a Docker Desktop Kubernetes development cluster with Istio service mesh support. It supports both sidecar and ambient modes, optional ingress gateway and Kubernetes Dashboard, and a zero-trust baseline for a target namespace (mTLS STRICT, default-deny authorization, and Kubernetes NetworkPolicies with optional internet egress). The scripts are compatible with PowerShell 5.1 and 7+ and are designed to integrate cleanly with Tilt + Helm workflows.